### PR TITLE
fix: update image tagging

### DIFF
--- a/.github/workflows/publish_sar_image.yaml
+++ b/.github/workflows/publish_sar_image.yaml
@@ -42,6 +42,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha
+            type=ref,event=branch
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.

--- a/.github/workflows/publish_sar_image.yaml
+++ b/.github/workflows/publish_sar_image.yaml
@@ -45,7 +45,7 @@ jobs:
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6.0.1
+        uses: docker/build-push-action@v6.10.0
         with:
           context: images/sar
           push: true

--- a/.github/workflows/publish_sar_image.yaml
+++ b/.github/workflows/publish_sar_image.yaml
@@ -40,6 +40,8 @@ jobs:
         uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.


### PR DESCRIPTION
Images will now tag to branch heads (`main`, `test`), as well as the short hashes of individual commits (`sha-bb6067f`).

Fixes an issue where the provenance of the image caused the image manifest to be formatted in such a way that it would cause an error when attempting to pull the image.