### PR TITLE
jlab 4.3.5 -> 4.0.7, remove some MyST packages

### DIFF
--- a/images/sar/Dockerfile
+++ b/images/sar/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/base-notebook:lab-4.3.4 as release
+FROM quay.io/jupyter/base-notebook:lab-4.0.7 as release
 
 # Base Stage ****************************************************************
 USER root
@@ -92,9 +92,6 @@ RUN mamba install -c conda-forge -y \
     ipympl \
     jupyterlab_widgets \
     jupyterlab-myst \
-    myst-nb \
-    mystmd \
-    myst-parser \
     ipywidgets \
     #jupyter-ai \
     jupyterlab-git \


### PR DESCRIPTION
- `jupyterlab` 4.3.5 -> 4.0.7 to support MyST MD link styling
- Remove packages needed for building a static JBook, but not needed for viewing myst md in notebooks in JupyterLab
    - `myst-nb`
    - `mystmd`
    - `myst-parser`