### PR TITLE
fix: update image source to quay.io

### DIFF
--- a/images/sar/Dockerfile
+++ b/images/sar/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:lab-4.5.3 as release
+FROM quay.io/jupyter/base-notebook:lab-4.5.3 as release
 
 # Base Stage ****************************************************************
 USER root


### PR DESCRIPTION
https://github.com/jupyter/docker-stacks images are no longer deployed to DockerHub (are we really using a pre-Oct 2023 version?), now only support [Quay.io](https://quay.io/repository/jupyter/base-notebook?tab=tags)