### PR TITLE
fix: `libshp2` -> `libshp4`

### DIFF
--- a/images/sar/Dockerfile
+++ b/images/sar/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get install --no-install-recommends --fix-missing -y \
     proj-bin \
     geotiff-bin \
     libshp-dev \
-    libshp2 \
+    libshp4 \
     libhdf5-dev \
     libnetcdf-dev \
     libgdal-dev \


### PR DESCRIPTION
`libshp2` is not a valid package on ubuntu-latest (24.04 LTS)

Should fix failing Actions run: https://github.com/ASFOpenSARlab/deployment-opensarlab-container/actions/runs/21602267133