### PR TITLE
fix: `zstandard` `v21` -> `v25`

### DIFF
--- a/images/sar/Dockerfile
+++ b/images/sar/Dockerfile
@@ -83,7 +83,7 @@ RUN mamba install -c conda-forge -y \
     plotly \
     'pyopenssl>=23.0.0' \
     zstd==1.5.5 \
-    zstandard==0.21.0 \
+    zstandard==0.25.0 \
     ### Install jupyter libaries
     kernda \
     jupyter-resource-usage \


### PR DESCRIPTION
🤞 Solves mamba environment, causing the failing action: https://github.com/ASFOpenSARlab/deployment-opensarlab-container/actions/runs/21602458633