### PR TITLE
reset PIXI_HOME to /home/jovyan/.pixi

### DIFF
--- a/images/sar/Dockerfile
+++ b/images/sar/Dockerfile
@@ -135,6 +135,8 @@ RUN set -eux; \
     mv -v "${PIXI_HOME}/bin/pixi" /usr/local/bin/pixi; \
     chmod 0755 /usr/local/bin/pixi; \
     pixi --version
+# reset PIXI_HOME to location on persistent volume after install for storing workspaces.toml
+ENV PIXI_HOME=/home/jovyan/.pixi
 
 WORKDIR /
 


### PR DESCRIPTION
reset PIXI_HOME to /home/jovyan/.pixi so it is in a persistent location that jovyan has write access to